### PR TITLE
Rearrange portrait intro and expand experience layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,549 @@
-<html>
-    <h1>
-        Hey ich bin Niklas
-    </h1>
-    <body>
-        <h2>Über mich</h2>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Über Niklas</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f5f5f5;
+            --card-bg: rgba(255, 255, 255, 0.8);
+            --text: #1f2933;
+            --accent: #2563eb;
+            --accent-soft: rgba(37, 99, 235, 0.18);
+            --shadow: 0 20px 45px rgba(31, 41, 51, 0.15);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+            background: linear-gradient(135deg, #a5b4fc, #93c5fd, #c4f1f9);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            padding: 3.25rem 1.5rem 1.5rem;
+            text-align: center;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: clamp(2.5rem, 5vw, 3.5rem);
+            letter-spacing: -0.03em;
+        }
+
+        header p {
+            margin: 0.75rem auto 0;
+            max-width: 60ch;
+            font-size: 1.15rem;
+            line-height: 1.7;
+        }
+
+        main {
+            width: min(1120px, 94vw);
+            margin: 0 auto 3rem;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 1.75rem;
+            grid-auto-flow: dense;
+        }
+
+        section {
+            background: var(--card-bg);
+            border-radius: 18px;
+            padding: 1.7rem;
+            backdrop-filter: blur(12px);
+            box-shadow: 0 16px 36px rgba(31, 41, 51, 0.12);
+            transition: transform 150ms ease, box-shadow 150ms ease;
+        }
+
+        section:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 22px 44px rgba(31, 41, 51, 0.18);
+        }
+
+        h2 {
+            margin-top: 0;
+            font-size: 1.6rem;
+        }
+
+        p {
+            line-height: 1.7;
+        }
+
+        ul {
+            padding-left: 1.2rem;
+            margin: 1rem 0 0;
+        }
+
+        li + li {
+            margin-top: 0.6rem;
+        }
+
+        .timeline {
+            list-style: none;
+            padding: 0;
+            margin: 1.5rem 0 0;
+            border-left: 3px solid var(--accent-soft);
+        }
+
+        .timeline li {
+            position: relative;
+            padding-left: 1.3rem;
+            margin-bottom: 1.35rem;
+        }
+
+        .timeline li::before {
+            content: "";
+            position: absolute;
+            left: -0.65rem;
+            top: 0.25rem;
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 0 5px var(--accent-soft);
+        }
+
+        .timeline h3 {
+            margin: 0;
+            font-size: 1.1rem;
+        }
+
+        .timeline span {
+            display: block;
+            margin-top: 0.35rem;
+            font-size: 0.95rem;
+            color: rgba(31, 41, 51, 0.75);
+        }
+
+        .experience-grid {
+            display: grid;
+            gap: 1.25rem;
+            margin-top: 1.5rem;
+        }
+
+        @media (min-width: 900px) {
+            .experience-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        .experience-item {
+            background: rgba(37, 99, 235, 0.12);
+            border-radius: 16px;
+            padding: 1.3rem 1.5rem 1.4rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .experience-item::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: 16px;
+            border: 1px solid rgba(37, 99, 235, 0.22);
+            pointer-events: none;
+        }
+
+        .experience-item h3 {
+            margin: 0;
+            font-size: 1.15rem;
+        }
+
+        .experience-item span {
+            display: block;
+            margin-top: 0.4rem;
+            font-size: 0.95rem;
+            color: rgba(31, 41, 51, 0.75);
+        }
+
+        .experience-item ul {
+            margin: 0.9rem 0 0;
+            padding-left: 1.1rem;
+        }
+
+        .badge-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.45rem;
+            margin-top: 1rem;
+        }
+
+        .intro-card {
+            padding: 0;
+            display: grid;
+            grid-template-columns: minmax(0, 1fr);
+            overflow: hidden;
+        }
+
+        @media (min-width: 880px) {
+            .intro-card {
+                grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+            }
+        }
+
+        @media (max-width: 879px) {
+            .intro-card figure {
+                order: -1;
+            }
+        }
+
+        .intro-copy {
+            padding: 2rem 2rem 1.85rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.15rem;
+        }
+
+        .intro-copy h2 {
+            margin: 0;
+            font-size: 1.65rem;
+        }
+
+        .intro-copy p {
+            margin: 0;
+        }
+
+        .intro-card figure {
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            background: linear-gradient(160deg, rgba(37, 99, 235, 0.1), rgba(147, 197, 253, 0.28));
+        }
+
+        .intro-card img {
+            width: 100%;
+            display: block;
+            flex: 1 1 60%;
+            min-height: 280px;
+            object-fit: cover;
+        }
+
+        @media (max-width: 600px) {
+            .intro-card img {
+                min-height: 220px;
+            }
+        }
+
+        .intro-card figcaption {
+            padding: 1.6rem 1.9rem 1.9rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.8rem;
+        }
+
+        .intro-card figcaption h3 {
+            margin: 0;
+            font-size: 1.25rem;
+        }
+
+        .intro-card figcaption p {
+            margin: 0;
+        }
+
+        .intro-card figcaption small {
+            font-size: 0.8rem;
+            opacity: 0.7;
+        }
+
+        .badge {
+            padding: 0.35rem 0.75rem;
+            border-radius: 999px;
+            background: rgba(37, 99, 235, 0.12);
+            color: var(--accent);
+            font-weight: 600;
+            font-size: 0.85rem;
+            letter-spacing: 0.01em;
+        }
+
+        .span-2 {
+            grid-column: span 1;
+        }
+
+        @media (min-width: 960px) {
+            .span-2 {
+                grid-column: 1 / -1;
+            }
+        }
+
+        .contact-grid {
+            display: grid;
+            gap: 0.85rem;
+            margin-top: 1.25rem;
+        }
+
+        .contact-item {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            font-weight: 600;
+        }
+
+        .contact-item span {
+            font-size: 0.95rem;
+            font-weight: 500;
+            opacity: 0.85;
+        }
+
+        .contact-item .cta {
+            margin-top: 0;
+        }
+
+        .highlight {
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        .cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-weight: 600;
+            color: var(--accent);
+            text-decoration: none;
+            margin-top: 1.5rem;
+        }
+
+        .cta span {
+            display: inline-block;
+            transition: transform 150ms ease;
+        }
+
+        .cta:hover span {
+            transform: translateX(4px);
+        }
+
+        .timeline ul {
+            margin-top: 0.75rem;
+            padding-left: 1.1rem;
+        }
+
+        footer {
+            text-align: center;
+            padding: 1.75rem 1.5rem 2.5rem;
+            font-size: 0.9rem;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0f172a;
+                --card-bg: rgba(15, 23, 42, 0.8);
+                --text: #e2e8f0;
+                --accent: #60a5fa;
+                --accent-soft: rgba(96, 165, 250, 0.32);
+                --shadow: 0 20px 45px rgba(15, 23, 42, 0.6);
+            }
+
+            body {
+                background: radial-gradient(circle at 20% 20%, #1e293b, #0f172a 55%, #020617);
+            }
+
+            .timeline span {
+                color: rgba(226, 232, 240, 0.75);
+            }
+
+            .intro-card figure {
+                background: linear-gradient(160deg, rgba(96, 165, 250, 0.18), rgba(15, 23, 42, 0.6));
+            }
+
+            .experience-item {
+                background: rgba(96, 165, 250, 0.14);
+            }
+
+            .experience-item::before {
+                border-color: rgba(96, 165, 250, 0.35);
+            }
+
+            .experience-item span {
+                color: rgba(226, 232, 240, 0.75);
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Hey, ich bin Niklas Henniger 👋</h1>
+        <p>
+            Software Engineer aus dem Kanton Basel-Landschaft mit einem Herz für clevere Automatisierungen und nutzerzentrierte Lösungen.
+            Bei Schneider &amp; Cie. AG in Basel verbinde ich Lobster Pro und Lobster Data zu robusten Kundenportalen, Schnittstellen und smarten Prozessen.
+        </p>
+    </header>
+
+    <main>
+        <section class="intro-card span-2" aria-label="Portrait und Über mich">
+            <div class="intro-copy">
+                <h2>Über mich</h2>
+                <p>
+                    Ich liebe es, Strukturen zu schaffen, die Menschen den Arbeitsalltag erleichtern. Bei Schneider &amp; Cie. AG gestalte ich
+                    digitale Produkte mit Lobster Pro und Lobster Data – vom Kundenportal über integrationsstarke Schnittstellen bis hin zu
+                    automatisierten Workflows, die Kolleg:innen mit wenigen Eingaben selbst anstoßen können.
+                </p>
+                <p>
+                    Geboren 1999 und tief im Dreiländereck verwurzelt, verbringe ich meine Freizeit gerne auf dem Tennisplatz oder beim
+                    Konzipieren neuer Webideen. Mein Motto: <span class="highlight">„Verstehen, verbessern, teilen.“</span> Aktuell tauche ich
+                    immer tiefer in KI-Anwendungen ein, um diese Expertise Schritt für Schritt ins Unternehmen zu tragen.
+                </p>
+                <div class="badge-list" aria-label="Kurzinformationen">
+                    <span class="badge">Geburtstag: 20.01.1999</span>
+                    <span class="badge">Basel-Landschaft, Schweiz</span>
+                    <span class="badge">Deutsch · Englisch (C1)</span>
+                </div>
+            </div>
+            <figure>
+                <img src="https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=800&q=80" alt="Portrait-Platzhalter" />
+                <figcaption>
+                    <h3>Dein zukünftiges Portrait</h3>
+                    <p>
+                        Hier kannst du später ganz einfach ein Foto von dir ergänzen – idealerweise im Hochformat. So erhält deine Landingpage
+                        ein noch persönlicheres Gesicht.
+                    </p>
+                    <small>Tipp: Ersetze die Bild-URL durch dein eigenes Foto, sobald du bereit bist.</small>
+                </figcaption>
+            </figure>
+        </section>
+
+        <section class="span-2">
+            <h2>Berufserfahrung</h2>
+            <div class="experience-grid">
+                <article class="experience-item">
+                    <h3>Software Engineer Lobster Solutions</h3>
+                    <span>Schneider &amp; Cie. AG, Basel · seit 05/2022</span>
+                    <ul>
+                        <li>Entwicklung und Betrieb des Kundenportals mit Lobster Pro und Lobster Data.</li>
+                        <li>Implementierung von Schnittstellen, die Kund:innen und Partnern Echtzeitdaten bereitstellen.</li>
+                        <li>Automatisierung interner Prozesse sowie Self-Service-Flows, die User mit ihrem Input starten können.</li>
+                    </ul>
+                </article>
+                <article class="experience-item">
+                    <h3>Software Engineer, Configurator Services</h3>
+                    <span>Vitra IT Services GmbH · 11/2021 – 04/2022</span>
+                    <ul>
+                        <li>Automatisierung von OFML-Anfragen und diversen Update-Prozessen mit C#.</li>
+                        <li>Entwicklung eines Lizenz-Auswertungstools in Java und C#.</li>
+                        <li>Gestaltung von Register-Pages für internationale Kampagnen.</li>
+                    </ul>
+                </article>
+                <article class="experience-item">
+                    <h3>Duales Studium Informatik (nicht abgeschlossen)</h3>
+                    <span>Vitra IT Services GmbH × DHBW Lörrach · 09/2020 – 10/2021</span>
+                    <ul>
+                        <li>Praxissemester mit Fokus auf Automatisierungs-Tools und OFML-Anfragen.</li>
+                    </ul>
+                </article>
+                <article class="experience-item">
+                    <h3>Ausbildung Fachinformatiker Systemintegration</h3>
+                    <span>Vitra IT Services GmbH · 07/2017 – 08/2020</span>
+                    <ul>
+                        <li>Internationale Windows 10 Rollouts vor Ort und remote.</li>
+                        <li>3rd-Level-Clientsupport sowie Betreuung von Webseiten und Wissensdatenbanken.</li>
+                        <li>Programmierung von C#- und Java-Anwendungen sowie Netzwerkadministration.</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section>
+            <h2>Ausbildung</h2>
+            <ul class="timeline">
+                <li>
+                    <h3>Duales Studium Informatik (ohne Abschluss)</h3>
+                    <span>DHBW Lörrach · 2020 – 2021</span>
+                </li>
+                <li>
+                    <h3>Ausbildung Fachinformatiker Systemintegration</h3>
+                    <span>Vitra IT Services · 2017 – 2020</span>
+                </li>
+                <li>
+                    <h3>Staatlich geprüfter informations- und kommunikationstechnischer Assistent</h3>
+                    <span>Gewerbeschule Lörrach · 2015 – 2017</span>
+                </li>
+                <li>
+                    <h3>Fachhochschulreife</h3>
+                    <span>Gewerbeschule Lörrach · 2015 – 2017</span>
+                </li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Skills & Tools</h2>
+            <p>Technologien und Methoden, die ich in Projekten einsetze:</p>
+            <div class="badge-list">
+                <span class="badge">C#</span>
+                <span class="badge">Java</span>
+                <span class="badge">HTML · CSS · JavaScript</span>
+                <span class="badge">Swift</span>
+                <span class="badge">SQL</span>
+                <span class="badge">PHP</span>
+                <span class="badge">Python</span>
+                <span class="badge">C++</span>
+                <span class="badge">MS Office</span>
+                <span class="badge">Figma</span>
+                <span class="badge">Jira</span>
+                <span class="badge">Agile Methoden · Scrum</span>
+                <span class="badge">ERM · EPK</span>
+                <span class="badge">Versionsverwaltung</span>
+                <span class="badge">Parallele & OOP Programmierung</span>
+            </div>
+        </section>
+
+        <section>
+            <h2>Engagement & Interessen</h2>
+            <ul>
+                <li>Webmaster für Tennisclub und Tennishalle Grenzach-Wyhlen – Konzeption, Pflege und Support.</li>
+                <li>Tennisspieler seit über 16 Jahren sowie ehemaliges Fußball-Clubmitglied.</li>
+                <li>Begeistert von klaren UI-Konzepten und kontinuierlichem Lernen.</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Aktueller Fokus</h2>
             <p>
-                Ich liebe es einfach mal so sachen zu wiederholen.
+                Mit Blick auf das kommende Jahr konzentriere ich mich darauf, KI-Initiativen bei Schneider &amp; Cie. greifbar zu machen:
+                Use-Cases identifizieren, Prototypen bauen und Teams beim Einsatz unterstützen.
             </p>
-            <h2>Was ich gerade mache</h2>
-            <p>
-                Baue meinen Blog
-            </p>
-        
-    </body>
+            <ul>
+                <li>Evaluierung von KI-gestützten Automatisierungen entlang bestehender Lobster-Prozesse.</li>
+                <li>Workshops und Wissensaufbau rund um verantwortungsvollen KI-Einsatz.</li>
+                <li>Proof-of-Concepts, die Mehrwert schnell sichtbar machen.</li>
+            </ul>
+        </section>
+
+        <section>
+            <h2>Kontakt</h2>
+            <p>Lass uns sprechen – egal ob zu spannenden Projekten, Automatisierungsideen oder einem Match auf dem Tennisplatz.</p>
+            <div class="contact-grid">
+                <div class="contact-item">
+                    📧
+                    <a class="cta" href="mailto:niklas.henniger@outlook.com">niklas.henniger@outlook.com <span>→</span></a>
+                </div>
+                <div class="contact-item">
+                    📞
+                    <span>+41 78 255 13 66</span>
+                </div>
+                <div class="contact-item">
+                    📍
+                    <span>Kanton Basel-Landschaft, Schweiz</span>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        © <span id="year"></span> Niklas. Gebaut mit ❤️ und einer Prise Neugier.
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- merge the portrait placeholder with the about copy in a two-column hero card so the image sits alongside your story on wide screens
- widen the Berufserfahrung area with a responsive grid of highlighted experience cards to shorten the section height while keeping detail

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e58926c9548322a75676a6c8a01f24